### PR TITLE
allow users to manually enter a Serial Number 

### DIFF
--- a/octoprint_prusaconnectbridge/templates/prusaconnectbridge_settings.jinja2
+++ b/octoprint_prusaconnectbridge/templates/prusaconnectbridge_settings.jinja2
@@ -1,9 +1,34 @@
 <div id="settings_plugin_prusaconnectbridge_content_area">
-    <h4>Prusa Connect Bridge Status</h4>
-    <p>
-        <strong>Serial Number (SN):</strong>
-        <span data-bind="text: settings.plugins.prusaconnectbridge.prusa_connect_sn() ? settings.plugins.prusaconnectbridge.prusa_connect_sn() : 'Not yet generated'"></span>
-    </p>
+    <h4>Prusa Connect Bridge Status & Identifiers</h4>
+    <form class="form-horizontal">
+        <div class="control-group">
+            <label class="control-label" for="pconnect_manual_sn">Manual Serial Number</label>
+            <div class="controls">
+                <input type="text" id="pconnect_manual_sn" name="prusa_connect_manual_sn" class="input-xlarge"
+                       data-bind="value: settings.plugins.prusaconnectbridge.prusa_connect_manual_sn"
+                       placeholder="Leave blank for auto-generated SN">
+                <span class="help-block">
+                    Optionally enter a specific Serial Number. If blank, an automatic SN (see 'Active SN' below) is used.
+                    Changing this after registration may require re-registration (use 'Clear Stored Credentials' button).
+                </span>
+            </div>
+        </div>
+        <div class="control-group">
+            <label class="control-label">Active Serial Number</label>
+            <div class="controls">
+                <span class="uneditable-input input-xlarge" data-bind="text: settings.plugins.prusaconnectbridge.prusa_connect_sn() ? settings.plugins.prusaconnectbridge.prusa_connect_sn() : 'Not set/generated'"></span>
+                <span class="help-block">This is the Serial Number currently used for Prusa Connect registration.</span>
+            </div>
+        </div>
+        <div class="control-group">
+            <label class="control-label">Active Fingerprint</label>
+            <div class="controls">
+                <span class="uneditable-input input-xlarge" data-bind="text: settings.plugins.prusaconnectbridge.prusa_connect_fingerprint() ? settings.plugins.prusaconnectbridge.prusa_connect_fingerprint().substring(0, 10) + '...' : 'Not set/generated'"></span>
+                 <span class="help-block">This is the Fingerprint currently used, derived from the Active SN.</span>
+            </div>
+        </div>
+    </form>
+
     <p>
         <strong>Registration Status:</strong>
         <span data-bind="text: prusaConnectStatusTextForUI"></span>

--- a/octoprint_prusaconnectbridge/templates/prusaconnectbridge_wizard.jinja2
+++ b/octoprint_prusaconnectbridge/templates/prusaconnectbridge_wizard.jinja2
@@ -7,6 +7,23 @@
         <p>Serial Number (SN): <strong data-bind="text: فعالsn_display">{{ data.sn }}</strong></p>
         <p>Fingerprint: <strong data-bind="text: فعالfingerprint_display">{{ data.fingerprint }}</strong></p>
         <p class="text-muted small">You can change these identifiers later in the Prusa Connect Bridge plugin settings if needed, but this usually requires re-registration.</p>
+    {% elif step_id == 'collect_sn_input' %}
+        <p>{{ data.description }}</p> {# Description from get_wizard_details #}
+        <form class="form-horizontal"> {# Standard OctoPrint wizard form styling #}
+            <div class="control-group">
+                <label class="control-label" for="wizard_manual_sn">Manual Serial Number (Optional)</label>
+                <div class="controls">
+                    <input type="text" id="wizard_manual_sn" name="manual_serial_number" class="input-xlarge"
+                           data-bind="value: ko_manual_sn_value"
+                           placeholder="Leave blank for auto-generation">
+                </div>
+            </div>
+        </form>
+        <p class="text-muted small">
+            If you provide a serial number, it will be used to register with Prusa Connect.
+            If left blank, the plugin will attempt to use a system-generated UUID or other available unique identifiers.
+            You can change this later in the plugin settings.
+        </p>
     {% elif step_id == 'register_prusa_connect' %}
         <p>
             To connect your printer to Prusa Connect, please click the link below to open the Prusa Connect website.


### PR DESCRIPTION
Modified get_settings_defaults in __init__.py to include prusa_connect_manual_sn=None.
Modified _initialize_identifiers in __init__.py to prioritize manual SN and update fingerprint.
Modified get_wizard_details in __init__.py to add a new step for manual SN input and updated the introduction step.
Modified on_wizard_proceed in __init__.py to handle the new SN input step, save the SN, re-initialize identifiers, and initiate registration.
Modified prusaconnectbridge_wizard.jinja2 to add the new SN input field and associated text for the collect_sn_input step.
Modified prusaconnectbridge_settings.jinja2 to include input for manual SN, display active SN and Fingerprint, and add relevant help text.
Modified on_settings_save in __init__.py to handle SN and server URL changes, re-initialize SDK, and manage re-registration.
Updated get_template_vars in __init__.py to include prusa_connect_manual_sn and prusa_connect_fingerprint.
Reviewed and updated clear_prusa_connect_settings in __init__.py to include clearing prusa_connect_manual_sn.