### PR TITLE
Chore: Standardize plugin description in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ import setuptools
 plugin_identifier = "OctoPrint-PrusaConnect-Bridge"
 plugin_package = "octoprint_prusaconnectbridge"
 plugin_name = "PrusaConnect-Bridge"
-plugin_version = "0.1.0"
-plugin_description = "A plugin for real-time G-code stream manipulation based on user-defined rules."
+plugin_version = "0.1.1"
+plugin_description = "OctoPrint plugin bridge to Prusa Connect (unofficial)."
 plugin_author = "GlitchLab.xyz"
 plugin_author_email = "contact@glitchlab.xyz"
 plugin_url = "https://github.com/VisualBoy/PrusaConnect-Bridge"
@@ -58,7 +58,7 @@ def params():
 	# Hook the plugin into the "octoprint.plugin" entry point, mapping the plugin_identifier to the plugin_package.
 	# That way OctoPrint will be able to find the plugin and load it.
 	entry_points = {
-		"octoprint.plugin": ["%s = %s" % (plugin_identifier, plugin_package)]
+		"octoprint.plugin": ["OctoPrint-PrusaConnect-Bridge = octoprint_prusaconnectbridge"]
 	}
 
 	return locals()


### PR DESCRIPTION
Updated the `plugin_description` in `setup.py` to match the description used in `octoprint_prusaconnectbridge/__init__.py` ("OctoPrint plugin bridge to Prusa Connect (unofficial).").

This change ensures consistency in how the plugin is described within the core project files.

Thank you for your interest into contributing to OctoPrint-LiveGCodeControl, it's highly appreciated!

Before submitting please make sure you have ticked all points on this checklist:

  * [ ] Your PR targets the devel branch.
  * [ ] Your PR was opened from a custom branch on your repository (no PRs from your version of master or devel please)
  * [ ] Your PR only contains relevant changes: no unrelated files, no dead code, ideally only one commit - rebase your PR if necessary!
  * [ ] Your changes follow the existing coding style.
  * [ ] You have tested your changes (please state how!)

Feel free to delete all this help text, then describe your PR further. You may use the template provided below to do that. The more details the better!

---

#### What does this PR do and why is it necessary?

#### How was it tested? How can it be tested by the reviewer?

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

