### PR TITLE
Fix: Upgrade prusa-connect-sdk-printer to >=0.7.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ requests>=2.32.3
 inotify_simple~=1.3.5
 mypy-extensions~=1.0.0
 urllib3>=1.21.1,<3
-prusa-connect-sdk
+prusa-connect-sdk-printer>=0.7.1

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ def params():
 	zip_safe = True
  
 	# Rrequirements:
-	install_requires = ["prusa-connect-sdk-printer==0.7.0"]
+	install_requires = ["prusa-connect-sdk-printer>=0.7.1"]
 
 	# Hook the plugin into the "octoprint.plugin" entry point, mapping the plugin_identifier to the plugin_package.
 	# That way OctoPrint will be able to find the plugin and load it.


### PR DESCRIPTION
Updates the **Prusa Connect SDK** dependency to version `0.7.1` or higher in setup.py and requirements.txt. This resolves an ImportError (bad magic number) caused by version 0.7.0 of the SDK, which was distributed with pre-compiled .pyc files that were missing their corresponding .py source files and were incompatible with your execution environment.

Version 0.7.1 (and higher, e.g., 0.8.1 as tested) of the SDK is correctly packaged with .py source files, allowing for successful compilation and import.